### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Navigated
 ## Usage XAML
 
 ```xaml
-xmlns:htmlLabel="clr-namespace:LabelHtml.Forms.Plugin.Abstractions;assembly=HtmlLabel.Forms.Plugin"
+xmlns:htmlLabel="clr-namespace:Plugin.HtmlLabel;assembly=Plugin.HtmlLabel"
 <htmlLabel:HtmlLabel Text="{Binding HtmlString}"/>
 ```
 
 ```xaml
-xmlns:htmlLabel="clr-namespace:LabelHtml.Forms.Plugin.Abstractions;assembly=HtmlLabel.Forms.Plugin"
+xmlns:htmlLabel="clr-namespace:Plugin.HtmlLabel;assembly=Plugin.HtmlLabel"
 <htmlLabel:HtmlLabel Text="{Binding HtmlString}" htmlLabel:HtmlLabel.MaxLines="2"/>
 ```
 


### PR DESCRIPTION
xmlns was incorrect in the XAML sample, at least for the 2.2.0 version I just grabbed. I confirmed this resolves properly for the Android and iOS targets.