### PR TITLE
Android specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ xmlns:htmlLabel="clr-namespace:LabelHtml.Forms.Plugin.Abstractions;assembly=Html
 <htmlLabel:HtmlLabel Text="{Binding HtmlString}" htmlLabel:HtmlLabel.MaxLines="2"/>
 ```
 
+## Android specific
+For Android it is possible to switch the HTML rendering between CompactMode (default) and LegacyMode.
+LegacyMode will give you white spacing between paragraphs, while CompactMode won't. 
+
+```xaml
+xmlns:htmlLabel="clr-namespace:LabelHtml.Forms.Plugin.Abstractions;assembly=HtmlLabel.Forms.Plugin"
+xmlns:htmlLabelAndroid="clr-namespace:LabelHtml.Forms.Plugin.PlatformSpecifics.Android;assembly=HtmlLabel.Forms.Plugin"
+<htmlLabel:HtmlLabel htmlLabelAndroid:HtmlLabel.HtmlLegacyModeEnabled="True" Text="{Binding HtmlString}"/>
+```
+
 ## Usage C#
 
 ```csharp

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -2,7 +2,7 @@
 
 # Indentation and spacing
 indent_size = 4
-indent_style = space
+indent_style = tab
 tab_width = 4
 
 # this. and Me. preferences

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,5 +1,16 @@
 ﻿[*.cs]
 
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
+
 # CA1010: Collections should implement generic interface
 dotnet_diagnostic.CA1010.severity = silent
 

--- a/src/HtmlLabel/Android/Renderer.cs
+++ b/src/HtmlLabel/Android/Renderer.cs
@@ -16,169 +16,169 @@ using PluginHtmlLabel = LabelHtml.Forms.Plugin.Abstractions;
 [assembly: ExportRenderer(typeof(PluginHtmlLabel.HtmlLabel), typeof(HtmlLabelRenderer))]
 namespace LabelHtml.Forms.Plugin.Droid
 {
-    /// <summary>
-    /// HtmlLable Implementation
-    /// </summary>
-    [Preserve(AllMembers = true)]
-    public class HtmlLabelRenderer : LabelRenderer
-    {
-        private const string _tagUlRegex = "[uU][lL]";
-        private const string _tagOlRegex = "[oO][lL]";
-        private const string _tagLiRegex = "[lL][iI]";
+	/// <summary>
+	/// HtmlLable Implementation
+	/// </summary>
+	[Preserve(AllMembers = true)]
+	public class HtmlLabelRenderer : LabelRenderer
+	{
+		private const string _tagUlRegex = "[uU][lL]";
+		private const string _tagOlRegex = "[oO][lL]";
+		private const string _tagLiRegex = "[lL][iI]";
 
-        /// <summary>
-        /// Create an instance of the renderer.
-        /// </summary>
-        /// <param name="context"></param>
-        public HtmlLabelRenderer(Android.Content.Context context) : base(context) { }
+		/// <summary>
+		/// Create an instance of the renderer.
+		/// </summary>
+		/// <param name="context"></param>
+		public HtmlLabelRenderer(Android.Content.Context context) : base(context) { }
 
-        /// <summary>
-        /// Used for registration with dependency service
-        /// </summary>
-        public static void Initialize() { }
+		/// <summary>
+		/// Used for registration with dependency service
+		/// </summary>
+		public static void Initialize() { }
 
-        /// <inheritdoc />
-        protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
-        {
-            base.OnElementChanged(e);
+		/// <inheritdoc />
+		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			base.OnElementChanged(e);
 
-            if (e == null || e.OldElement != null || Element == null)
-            {
-                return;
-            }
+			if (e == null || e.OldElement != null || Element == null)
+			{
+				return;
+			}
 
-            try
-            {
-                ProcessText();
-            }
-            catch (System.Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine(@$"ERROR: ${ex.Message}");
-            }
-        }
+			try
+			{
+				ProcessText();
+			}
+			catch (System.Exception ex)
+			{
+				System.Diagnostics.Debug.WriteLine(@$"ERROR: ${ex.Message}");
+			}
+		}
 
-        /// <inheritdoc />
-        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            base.OnElementPropertyChanged(sender, e);
-            if (e != null && PluginHtmlLabel.RendererHelper.RequireProcess(e.PropertyName))
-            {
-                try
-                {
-                    ProcessText();
-                }
-                catch (System.Exception ex)
-                {
-                    System.Diagnostics.Debug.WriteLine(@$"ERROR: ${ex.Message}");
-                }
-            }
-        }
+		/// <inheritdoc />
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+			if (e != null && PluginHtmlLabel.RendererHelper.RequireProcess(e.PropertyName))
+			{
+				try
+				{
+					ProcessText();
+				}
+				catch (System.Exception ex)
+				{
+					System.Diagnostics.Debug.WriteLine(@$"ERROR: ${ex.Message}");
+				}
+			}
+		}
 
-        private void ProcessText()
-        {
-            if (Control == null || Element == null)
-            {
-                return;
-            }
+		private void ProcessText()
+		{
+			if (Control == null || Element == null)
+			{
+				return;
+			}
 
-            Color linkColor = ((PluginHtmlLabel.HtmlLabel)Element).LinkColor;
-            if (!linkColor.IsDefault)
-            {
-                Control.SetLinkTextColor(linkColor.ToAndroid());
-            }
+			Color linkColor = ((PluginHtmlLabel.HtmlLabel)Element).LinkColor;
+			if (!linkColor.IsDefault)
+			{
+				Control.SetLinkTextColor(linkColor.ToAndroid());
+			}
 
-            Control.SetIncludeFontPadding(false);
-            var isRtl = Device.FlowDirection == FlowDirection.RightToLeft;
-            var styledHtml = new PluginHtmlLabel.RendererHelper(Element, Control.Text, Device.RuntimePlatform, isRtl).ToString();
-            /* 
+			Control.SetIncludeFontPadding(false);
+			var isRtl = Device.FlowDirection == FlowDirection.RightToLeft;
+			var styledHtml = new PluginHtmlLabel.RendererHelper(Element, Control.Text, Device.RuntimePlatform, isRtl).ToString();
+			/* 
 			 * Android's TextView doesn't support lists.
 			 * List tags must be replaces with custom tags,
 			 * that it will be renderer by a custom tag handler.
 			 */
-            styledHtml = styledHtml
-                ?.ReplaceTag(_tagUlRegex, ListTagHandler.TagUl)
-                ?.ReplaceTag(_tagOlRegex, ListTagHandler.TagOl)
-                ?.ReplaceTag(_tagLiRegex, ListTagHandler.TagLi);
+			styledHtml = styledHtml
+				?.ReplaceTag(_tagUlRegex, ListTagHandler.TagUl)
+				?.ReplaceTag(_tagOlRegex, ListTagHandler.TagOl)
+				?.ReplaceTag(_tagLiRegex, ListTagHandler.TagLi);
 
-            if (styledHtml != null)
-            {
-                SetText((PluginHtmlLabel.HtmlLabel)Element, Control, styledHtml);
-            }
-        }
+			if (styledHtml != null)
+			{
+				SetText((PluginHtmlLabel.HtmlLabel)Element, Control, styledHtml);
+			}
+		}
 
-        private void SetText(PluginHtmlLabel.HtmlLabel element, TextView control, string html)
-        {
+		private void SetText(PluginHtmlLabel.HtmlLabel element, TextView control, string html)
+		{
 
-            // Set the type of content and the custom tag list handler
-            using var listTagHandler = new ListTagHandler();
-            ISpanned sequence = Build.VERSION.SdkInt >= BuildVersionCodes.N ?
-                Html.FromHtml(html, element.On<Xamarin.Forms.PlatformConfiguration.Android>().GetHtmlLegacyModeEnabled() ? FromHtmlOptions.ModeLegacy : FromHtmlOptions.ModeCompact, null, listTagHandler) :
-                Html.FromHtml(html, null, listTagHandler);
-            using var strBuilder = new SpannableStringBuilder(sequence);
+			// Set the type of content and the custom tag list handler
+			using var listTagHandler = new ListTagHandler();
+			ISpanned sequence = Build.VERSION.SdkInt >= BuildVersionCodes.N ?
+				Html.FromHtml(html, element.On<Xamarin.Forms.PlatformConfiguration.Android>().GetHtmlLegacyModeEnabled() ? FromHtmlOptions.ModeLegacy : FromHtmlOptions.ModeCompact, null, listTagHandler) :
+				Html.FromHtml(html, null, listTagHandler);
+			using var strBuilder = new SpannableStringBuilder(sequence);
 
-            // Make clickable links
-            if (!Element.GestureRecognizers.Any())
-            {
-                control.MovementMethod = LinkMovementMethod.Instance;
-                URLSpan[] urls = strBuilder
-                .GetSpans(0, sequence.Length(), Class.FromType(typeof(URLSpan)))
-                .Cast<URLSpan>()
-                .ToArray();
-                foreach (URLSpan span in urls)
-                {
-                    MakeLinkClickable(strBuilder, span);
-                }
-            }
+			// Make clickable links
+			if (!Element.GestureRecognizers.Any())
+			{
+				control.MovementMethod = LinkMovementMethod.Instance;
+				URLSpan[] urls = strBuilder
+				.GetSpans(0, sequence.Length(), Class.FromType(typeof(URLSpan)))
+				.Cast<URLSpan>()
+				.ToArray();
+				foreach (URLSpan span in urls)
+				{
+					MakeLinkClickable(strBuilder, span);
+				}
+			}
 
-            // Android adds an unnecessary "\n" that must be removed
-            using ISpanned value = RemoveLastChar(strBuilder);
+			// Android adds an unnecessary "\n" that must be removed
+			using ISpanned value = RemoveLastChar(strBuilder);
 
-            // Finally sets the value of the TextView 
-            control.SetText(value, TextView.BufferType.Spannable);
-        }
+			// Finally sets the value of the TextView 
+			control.SetText(value, TextView.BufferType.Spannable);
+		}
 
-        private void MakeLinkClickable(ISpannable strBuilder, URLSpan span)
-        {
-            var start = strBuilder.GetSpanStart(span);
-            var end = strBuilder.GetSpanEnd(span);
-            SpanTypes flags = strBuilder.GetSpanFlags(span);
-            var clickable = new HtmlLabelClickableSpan((PluginHtmlLabel.HtmlLabel)Element, span);
-            strBuilder.SetSpan(clickable, start, end, flags);
-            strBuilder.RemoveSpan(span);
-        }
+		private void MakeLinkClickable(ISpannable strBuilder, URLSpan span)
+		{
+			var start = strBuilder.GetSpanStart(span);
+			var end = strBuilder.GetSpanEnd(span);
+			SpanTypes flags = strBuilder.GetSpanFlags(span);
+			var clickable = new HtmlLabelClickableSpan((PluginHtmlLabel.HtmlLabel)Element, span);
+			strBuilder.SetSpan(clickable, start, end, flags);
+			strBuilder.RemoveSpan(span);
+		}
 
-        private static ISpanned RemoveLastChar(ICharSequence text)
-        {
-            var builder = new SpannableStringBuilder(text);
-            if (text.Length() != 0)
-            {
-                _ = builder.Delete(text.Length() - 1, text.Length());
-            }
+		private static ISpanned RemoveLastChar(ICharSequence text)
+		{
+			var builder = new SpannableStringBuilder(text);
+			if (text.Length() != 0)
+			{
+				_ = builder.Delete(text.Length() - 1, text.Length());
+			}
 
-            return builder;
-        }
+			return builder;
+		}
 
-        private class HtmlLabelClickableSpan : ClickableSpan
-        {
-            private readonly PluginHtmlLabel.HtmlLabel _label;
-            private readonly URLSpan _span;
+		private class HtmlLabelClickableSpan : ClickableSpan
+		{
+			private readonly PluginHtmlLabel.HtmlLabel _label;
+			private readonly URLSpan _span;
 
-            public HtmlLabelClickableSpan(PluginHtmlLabel.HtmlLabel label, URLSpan span)
-            {
-                _label = label;
-                _span = span;
-            }
+			public HtmlLabelClickableSpan(PluginHtmlLabel.HtmlLabel label, URLSpan span)
+			{
+				_label = label;
+				_span = span;
+			}
 
-            public override void UpdateDrawState(TextPaint ds)
-            {
-                base.UpdateDrawState(ds);
-                ds.UnderlineText = _label.UnderlineText;
-            }
+			public override void UpdateDrawState(TextPaint ds)
+			{
+				base.UpdateDrawState(ds);
+				ds.UnderlineText = _label.UnderlineText;
+			}
 
-            public override void OnClick(Android.Views.View widget)
-            {
-                PluginHtmlLabel.RendererHelper.HandleUriClick(_label, _span.URL);
-            }
-        }
-    }
+			public override void OnClick(Android.Views.View widget)
+			{
+				PluginHtmlLabel.RendererHelper.HandleUriClick(_label, _span.URL);
+			}
+		}
+	}
 }

--- a/src/HtmlLabel/Android/Renderer.cs
+++ b/src/HtmlLabel/Android/Renderer.cs
@@ -1,183 +1,184 @@
-using System.ComponentModel;
-using System.Linq;
 using Android.OS;
 using Android.Text;
 using Android.Text.Method;
 using Android.Text.Style;
 using Android.Widget;
 using Java.Lang;
-using LabelHtml.Forms.Plugin.Abstractions;
 using LabelHtml.Forms.Plugin.Droid;
+using LabelHtml.Forms.Plugin.PlatformSpecifics.Android;
+using System.ComponentModel;
+using System.Linq;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.Android;
+using PluginHtmlLabel = LabelHtml.Forms.Plugin.Abstractions;
 
-[assembly: ExportRenderer(typeof(HtmlLabel), typeof(HtmlLabelRenderer))]
+[assembly: ExportRenderer(typeof(PluginHtmlLabel.HtmlLabel), typeof(HtmlLabelRenderer))]
 namespace LabelHtml.Forms.Plugin.Droid
 {
-	/// <summary>
-	/// HtmlLable Implementation
-	/// </summary>
-	[Preserve(AllMembers = true)]
+    /// <summary>
+    /// HtmlLable Implementation
+    /// </summary>
+    [Preserve(AllMembers = true)]
     public class HtmlLabelRenderer : LabelRenderer
     {
-		private const string _tagUlRegex = "[uU][lL]";
-		private const string _tagOlRegex = "[oO][lL]";
-		private const string _tagLiRegex = "[lL][iI]";
+        private const string _tagUlRegex = "[uU][lL]";
+        private const string _tagOlRegex = "[oO][lL]";
+        private const string _tagLiRegex = "[lL][iI]";
 
-		/// <summary>
-		/// Create an instance of the renderer.
-		/// </summary>
-		/// <param name="context"></param>
-		public HtmlLabelRenderer(Android.Content.Context context) : base(context) { }
-		
-	    /// <summary>
-	    /// Used for registration with dependency service
-	    /// </summary>
-	    public static void Initialize() { }
+        /// <summary>
+        /// Create an instance of the renderer.
+        /// </summary>
+        /// <param name="context"></param>
+        public HtmlLabelRenderer(Android.Content.Context context) : base(context) { }
 
-		/// <inheritdoc />
-		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
-		{
-			base.OnElementChanged(e);
+        /// <summary>
+        /// Used for registration with dependency service
+        /// </summary>
+        public static void Initialize() { }
 
-			if (e == null || e.OldElement != null || Element == null)
-			{
-				return;
-			}
+        /// <inheritdoc />
+        protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+        {
+            base.OnElementChanged(e);
 
-			try
-			{
-				ProcessText();
-			}
-			catch (System.Exception ex)
-			{
-				System.Diagnostics.Debug.WriteLine(@$"ERROR: ${ex.Message}");
-			}
-		}
+            if (e == null || e.OldElement != null || Element == null)
+            {
+                return;
+            }
 
-		/// <inheritdoc />
-		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
-		{
-			base.OnElementPropertyChanged(sender, e);
-			if (e != null && RendererHelper.RequireProcess(e.PropertyName))
-			{
-				try
-				{
-					ProcessText();
-				}
-				catch (System.Exception ex)
-				{
-					System.Diagnostics.Debug.WriteLine(@$"ERROR: ${ex.Message}");
-				}
-			}
-		}
+            try
+            {
+                ProcessText();
+            }
+            catch (System.Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(@$"ERROR: ${ex.Message}");
+            }
+        }
 
-		private void ProcessText()
-		{
-			if (Control == null || Element == null)
-			{
-				return;
-			}
+        /// <inheritdoc />
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            base.OnElementPropertyChanged(sender, e);
+            if (e != null && PluginHtmlLabel.RendererHelper.RequireProcess(e.PropertyName))
+            {
+                try
+                {
+                    ProcessText();
+                }
+                catch (System.Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine(@$"ERROR: ${ex.Message}");
+                }
+            }
+        }
 
-			Color linkColor = ((HtmlLabel)Element).LinkColor;
-			if (!linkColor.IsDefault)
-			{
-				Control.SetLinkTextColor(linkColor.ToAndroid());
-			}
+        private void ProcessText()
+        {
+            if (Control == null || Element == null)
+            {
+                return;
+            }
 
-			Control.SetIncludeFontPadding(false);
-			var isRtl = Device.FlowDirection == FlowDirection.RightToLeft;
-			var styledHtml = new RendererHelper(Element, Control.Text, Device.RuntimePlatform, isRtl).ToString();
-			/* 
+            Color linkColor = ((PluginHtmlLabel.HtmlLabel)Element).LinkColor;
+            if (!linkColor.IsDefault)
+            {
+                Control.SetLinkTextColor(linkColor.ToAndroid());
+            }
+
+            Control.SetIncludeFontPadding(false);
+            var isRtl = Device.FlowDirection == FlowDirection.RightToLeft;
+            var styledHtml = new PluginHtmlLabel.RendererHelper(Element, Control.Text, Device.RuntimePlatform, isRtl).ToString();
+            /* 
 			 * Android's TextView doesn't support lists.
 			 * List tags must be replaces with custom tags,
 			 * that it will be renderer by a custom tag handler.
 			 */
-			styledHtml = styledHtml
-				?.ReplaceTag(_tagUlRegex, ListTagHandler.TagUl)
-				?.ReplaceTag(_tagOlRegex, ListTagHandler.TagOl)
-				?.ReplaceTag(_tagLiRegex, ListTagHandler.TagLi);
-			
-			if (styledHtml != null)
-			{
-				SetText(Control, styledHtml);
-			}
-		}
+            styledHtml = styledHtml
+                ?.ReplaceTag(_tagUlRegex, ListTagHandler.TagUl)
+                ?.ReplaceTag(_tagOlRegex, ListTagHandler.TagOl)
+                ?.ReplaceTag(_tagLiRegex, ListTagHandler.TagLi);
 
-		private void SetText(TextView control, string html)
-		{
+            if (styledHtml != null)
+            {
+                SetText((PluginHtmlLabel.HtmlLabel)Element, Control, styledHtml);
+            }
+        }
 
-			// Set the type of content and the custom tag list handler
-			using var listTagHandler = new ListTagHandler();
-			ISpanned sequence = Build.VERSION.SdkInt >= BuildVersionCodes.N ?
-				Html.FromHtml(html, FromHtmlOptions.ModeCompact, null, listTagHandler) :
-				Html.FromHtml(html, null, listTagHandler);
-			using var strBuilder = new SpannableStringBuilder(sequence);
+        private void SetText(PluginHtmlLabel.HtmlLabel element, TextView control, string html)
+        {
 
-			// Make clickable links
-			if (!Element.GestureRecognizers.Any())
-			{
-				control.MovementMethod = LinkMovementMethod.Instance;
-				URLSpan[] urls = strBuilder
-				.GetSpans(0, sequence.Length(), Class.FromType(typeof(URLSpan)))
-				.Cast<URLSpan>()
-				.ToArray();
-				foreach (URLSpan span in urls)
-				{
-					MakeLinkClickable(strBuilder, (URLSpan)span);
-				}
-			}			
+            // Set the type of content and the custom tag list handler
+            using var listTagHandler = new ListTagHandler();
+            ISpanned sequence = Build.VERSION.SdkInt >= BuildVersionCodes.N ?
+                Html.FromHtml(html, element.On<Xamarin.Forms.PlatformConfiguration.Android>().GetHtmlLegacyModeEnabled() ? FromHtmlOptions.ModeLegacy : FromHtmlOptions.ModeCompact, null, listTagHandler) :
+                Html.FromHtml(html, null, listTagHandler);
+            using var strBuilder = new SpannableStringBuilder(sequence);
 
-			// Android adds an unnecessary "\n" that must be removed
-			using ISpanned value = RemoveLastChar(strBuilder);
+            // Make clickable links
+            if (!Element.GestureRecognizers.Any())
+            {
+                control.MovementMethod = LinkMovementMethod.Instance;
+                URLSpan[] urls = strBuilder
+                .GetSpans(0, sequence.Length(), Class.FromType(typeof(URLSpan)))
+                .Cast<URLSpan>()
+                .ToArray();
+                foreach (URLSpan span in urls)
+                {
+                    MakeLinkClickable(strBuilder, span);
+                }
+            }
 
-			// Finally sets the value of the TextView 
-			control.SetText(value, TextView.BufferType.Spannable);
-		}
+            // Android adds an unnecessary "\n" that must be removed
+            using ISpanned value = RemoveLastChar(strBuilder);
 
-	    private void MakeLinkClickable(ISpannable strBuilder, URLSpan span)
-		{
-			var start = strBuilder.GetSpanStart(span);
-			var end = strBuilder.GetSpanEnd(span);
-			SpanTypes flags = strBuilder.GetSpanFlags(span);
-			var clickable = new HtmlLabelClickableSpan((HtmlLabel)Element, span);
-			strBuilder.SetSpan(clickable, start, end, flags);
-			strBuilder.RemoveSpan(span);
-		}
+            // Finally sets the value of the TextView 
+            control.SetText(value, TextView.BufferType.Spannable);
+        }
 
-		private static ISpanned RemoveLastChar(ICharSequence text)
-		{
-			var builder = new SpannableStringBuilder(text);
-			if (text.Length() != 0)
-			{
-				_ = builder.Delete(text.Length() - 1, text.Length());
-			}
+        private void MakeLinkClickable(ISpannable strBuilder, URLSpan span)
+        {
+            var start = strBuilder.GetSpanStart(span);
+            var end = strBuilder.GetSpanEnd(span);
+            SpanTypes flags = strBuilder.GetSpanFlags(span);
+            var clickable = new HtmlLabelClickableSpan((PluginHtmlLabel.HtmlLabel)Element, span);
+            strBuilder.SetSpan(clickable, start, end, flags);
+            strBuilder.RemoveSpan(span);
+        }
 
-			return builder;
-		}
+        private static ISpanned RemoveLastChar(ICharSequence text)
+        {
+            var builder = new SpannableStringBuilder(text);
+            if (text.Length() != 0)
+            {
+                _ = builder.Delete(text.Length() - 1, text.Length());
+            }
 
-		private class HtmlLabelClickableSpan : ClickableSpan
-		{
-			private readonly HtmlLabel _label;
-			private readonly URLSpan _span;
+            return builder;
+        }
 
-			public HtmlLabelClickableSpan(HtmlLabel label, URLSpan span)
-			{
-				_label = label;
-				_span = span;
-			}
+        private class HtmlLabelClickableSpan : ClickableSpan
+        {
+            private readonly PluginHtmlLabel.HtmlLabel _label;
+            private readonly URLSpan _span;
 
-			public override void UpdateDrawState(TextPaint ds)
-			{
-				base.UpdateDrawState(ds);
-				ds.UnderlineText = _label.UnderlineText;
-			}
+            public HtmlLabelClickableSpan(PluginHtmlLabel.HtmlLabel label, URLSpan span)
+            {
+                _label = label;
+                _span = span;
+            }
 
-			public override void OnClick(Android.Views.View widget)
-			{
-				RendererHelper.HandleUriClick(_label, _span.URL);
-			}
-		}
-	}
+            public override void UpdateDrawState(TextPaint ds)
+            {
+                base.UpdateDrawState(ds);
+                ds.UnderlineText = _label.UnderlineText;
+            }
+
+            public override void OnClick(Android.Views.View widget)
+            {
+                PluginHtmlLabel.RendererHelper.HandleUriClick(_label, _span.URL);
+            }
+        }
+    }
 }

--- a/src/HtmlLabel/Shared/HtmlLabel.cs
+++ b/src/HtmlLabel/Shared/HtmlLabel.cs
@@ -6,85 +6,85 @@ using Xamarin.Forms;
 [assembly: InternalsVisibleTo("HtmlLabel.Forms.Plugin.Shared.Tests")]
 namespace LabelHtml.Forms.Plugin.Abstractions
 {
-    /// <inheritdoc />
-    /// <summary>
-    /// A label that is able to display HTML content
-    /// </summary>
-    public class HtmlLabel : Label
-    {
-        /// <summary>
-        /// Identify the UnderlineText property.
-        /// </summary>
-        public static readonly BindableProperty UnderlineTextProperty =
-            BindableProperty.Create(nameof(UnderlineText), typeof(bool), typeof(HtmlLabel), true);
+	/// <inheritdoc />
+	/// <summary>
+	/// A label that is able to display HTML content
+	/// </summary>
+	public class HtmlLabel : Label
+	{
+		/// <summary>
+		/// Identify the UnderlineText property.
+		/// </summary>
+		public static readonly BindableProperty UnderlineTextProperty =
+			BindableProperty.Create(nameof(UnderlineText), typeof(bool), typeof(HtmlLabel), true);
 
-        /// <summary>
-        /// Get or set if hyperlinks are underlined.
-        /// </summary>
-        public bool UnderlineText
-        {
-            get { return (bool)GetValue(UnderlineTextProperty); }
-            set { SetValue(UnderlineTextProperty, value); }
-        }
+		/// <summary>
+		/// Get or set if hyperlinks are underlined.
+		/// </summary>
+		public bool UnderlineText
+		{
+			get { return (bool)GetValue(UnderlineTextProperty); }
+			set { SetValue(UnderlineTextProperty, value); }
+		}
 
-        /// <summary>
-        /// Identify the LinkColor property.
-        /// </summary>
-        public static readonly BindableProperty LinkColorProperty =
-            BindableProperty.Create(nameof(LinkColor), typeof(Color), typeof(HtmlLabel), default);
+		/// <summary>
+		/// Identify the LinkColor property.
+		/// </summary>
+		public static readonly BindableProperty LinkColorProperty =
+			BindableProperty.Create(nameof(LinkColor), typeof(Color), typeof(HtmlLabel), default);
 
-        /// <summary>
-        /// Get or set the color of hyperlinks.
-        /// </summary>
-        public Color LinkColor
-        {
-            get { return (Color)GetValue(LinkColorProperty); }
-            set { SetValue(LinkColorProperty, value); }
-        }
+		/// <summary>
+		/// Get or set the color of hyperlinks.
+		/// </summary>
+		public Color LinkColor
+		{
+			get { return (Color)GetValue(LinkColorProperty); }
+			set { SetValue(LinkColorProperty, value); }
+		}
 
-        /// <summary>
-        /// Identify the BrowserLaunchOptions property.
-        /// </summary>
-        public static readonly BindableProperty BrowserLaunchOptionsProperty =
-            BindableProperty.Create(nameof(BrowserLaunchOptions), typeof(BrowserLaunchOptions), typeof(HtmlLabel), default);
+		/// <summary>
+		/// Identify the BrowserLaunchOptions property.
+		/// </summary>
+		public static readonly BindableProperty BrowserLaunchOptionsProperty =
+			BindableProperty.Create(nameof(BrowserLaunchOptions), typeof(BrowserLaunchOptions), typeof(HtmlLabel), default);
 
-        /// <summary>
-        /// Get or set the options to use when opening a web link. <see cref="https://docs.microsoft.com/en-us/xamarin/essentials/open-browser"/>
-        /// </summary>
-        public BrowserLaunchOptions BrowserLaunchOptions
-        {
-            get { return (BrowserLaunchOptions)GetValue(BrowserLaunchOptionsProperty); }
-            set { SetValue(BrowserLaunchOptionsProperty, value); }
-        }
+		/// <summary>
+		/// Get or set the options to use when opening a web link. <see cref="https://docs.microsoft.com/en-us/xamarin/essentials/open-browser"/>
+		/// </summary>
+		public BrowserLaunchOptions BrowserLaunchOptions
+		{
+			get { return (BrowserLaunchOptions)GetValue(BrowserLaunchOptionsProperty); }
+			set { SetValue(BrowserLaunchOptionsProperty, value); }
+		}
 
-        /// <summary>
-        /// Fires before the open URL request is done.
-        /// </summary>
-        public event EventHandler<WebNavigatingEventArgs> Navigating;
+		/// <summary>
+		/// Fires before the open URL request is done.
+		/// </summary>
+		public event EventHandler<WebNavigatingEventArgs> Navigating;
 
-        /// <summary>
-        /// Fires when the open URL request is done.
-        /// </summary>
-        public event EventHandler<WebNavigatingEventArgs> Navigated;
+		/// <summary>
+		/// Fires when the open URL request is done.
+		/// </summary>
+		public event EventHandler<WebNavigatingEventArgs> Navigated;
 
-        /// <summary>
-        /// Send the Navigating event
-        /// </summary>
-        /// <param name="args"></param>
-        internal void SendNavigating(WebNavigatingEventArgs args)
-        {
-            Navigating?.Invoke(this, args);
-        }
+		/// <summary>
+		/// Send the Navigating event
+		/// </summary>
+		/// <param name="args"></param>
+		internal void SendNavigating(WebNavigatingEventArgs args)
+		{
+			Navigating?.Invoke(this, args);
+		}
 
-        /// <summary>
-        /// Send the Navigated event
-        /// </summary>
-        /// <param name="args"></param>
-        internal void SendNavigated(WebNavigatingEventArgs args)
-        {
-            Navigated?.Invoke(this, args);
-        }
+		/// <summary>
+		/// Send the Navigated event
+		/// </summary>
+		/// <param name="args"></param>
+		internal void SendNavigated(WebNavigatingEventArgs args)
+		{
+			Navigated?.Invoke(this, args);
+		}
 
-        public bool HtmlLegacyModeEnabled { get; set; } = false;
-    }
+		public bool HtmlLegacyModeEnabled { get; set; } = false;
+	}
 }

--- a/src/HtmlLabel/Shared/HtmlLabel.cs
+++ b/src/HtmlLabel/Shared/HtmlLabel.cs
@@ -6,83 +6,85 @@ using Xamarin.Forms;
 [assembly: InternalsVisibleTo("HtmlLabel.Forms.Plugin.Shared.Tests")]
 namespace LabelHtml.Forms.Plugin.Abstractions
 {
-	/// <inheritdoc />
-	/// <summary>
-	/// A label that is able to display HTML content
-	/// </summary>
-	public class HtmlLabel : Label
-	{
-		/// <summary>
-		/// Identify the UnderlineText property.
-		/// </summary>
-		public static readonly BindableProperty UnderlineTextProperty =
-			BindableProperty.Create(nameof(UnderlineText), typeof(bool), typeof(HtmlLabel), true);
+    /// <inheritdoc />
+    /// <summary>
+    /// A label that is able to display HTML content
+    /// </summary>
+    public class HtmlLabel : Label
+    {
+        /// <summary>
+        /// Identify the UnderlineText property.
+        /// </summary>
+        public static readonly BindableProperty UnderlineTextProperty =
+            BindableProperty.Create(nameof(UnderlineText), typeof(bool), typeof(HtmlLabel), true);
 
-		/// <summary>
-		/// Get or set if hyperlinks are underlined.
-		/// </summary>
-		public bool UnderlineText
-		{
-			get { return (bool)GetValue(UnderlineTextProperty); }
-			set { SetValue(UnderlineTextProperty, value); }
-		}
+        /// <summary>
+        /// Get or set if hyperlinks are underlined.
+        /// </summary>
+        public bool UnderlineText
+        {
+            get { return (bool)GetValue(UnderlineTextProperty); }
+            set { SetValue(UnderlineTextProperty, value); }
+        }
 
-		/// <summary>
-		/// Identify the LinkColor property.
-		/// </summary>
-		public static readonly BindableProperty LinkColorProperty =
-			BindableProperty.Create(nameof(LinkColor), typeof(Color), typeof(HtmlLabel), default);
+        /// <summary>
+        /// Identify the LinkColor property.
+        /// </summary>
+        public static readonly BindableProperty LinkColorProperty =
+            BindableProperty.Create(nameof(LinkColor), typeof(Color), typeof(HtmlLabel), default);
 
-		/// <summary>
-		/// Get or set the color of hyperlinks.
-		/// </summary>
-		public Color LinkColor
-		{
-			get { return (Color)GetValue(LinkColorProperty); }
-			set { SetValue(LinkColorProperty, value); }
-		}
+        /// <summary>
+        /// Get or set the color of hyperlinks.
+        /// </summary>
+        public Color LinkColor
+        {
+            get { return (Color)GetValue(LinkColorProperty); }
+            set { SetValue(LinkColorProperty, value); }
+        }
 
-		/// <summary>
-		/// Identify the BrowserLaunchOptions property.
-		/// </summary>
-		public static readonly BindableProperty BrowserLaunchOptionsProperty =
-			BindableProperty.Create(nameof(BrowserLaunchOptions), typeof(BrowserLaunchOptions), typeof(HtmlLabel), default);
+        /// <summary>
+        /// Identify the BrowserLaunchOptions property.
+        /// </summary>
+        public static readonly BindableProperty BrowserLaunchOptionsProperty =
+            BindableProperty.Create(nameof(BrowserLaunchOptions), typeof(BrowserLaunchOptions), typeof(HtmlLabel), default);
 
-		/// <summary>
-		/// Get or set the options to use when opening a web link. <see cref="https://docs.microsoft.com/en-us/xamarin/essentials/open-browser"/>
-		/// </summary>
-		public BrowserLaunchOptions BrowserLaunchOptions
-		{
-			get { return (BrowserLaunchOptions)GetValue(BrowserLaunchOptionsProperty); }
-			set { SetValue(BrowserLaunchOptionsProperty, value); }
-		}
+        /// <summary>
+        /// Get or set the options to use when opening a web link. <see cref="https://docs.microsoft.com/en-us/xamarin/essentials/open-browser"/>
+        /// </summary>
+        public BrowserLaunchOptions BrowserLaunchOptions
+        {
+            get { return (BrowserLaunchOptions)GetValue(BrowserLaunchOptionsProperty); }
+            set { SetValue(BrowserLaunchOptionsProperty, value); }
+        }
 
-		/// <summary>
-		/// Fires before the open URL request is done.
-		/// </summary>
-		public event EventHandler<WebNavigatingEventArgs> Navigating;
+        /// <summary>
+        /// Fires before the open URL request is done.
+        /// </summary>
+        public event EventHandler<WebNavigatingEventArgs> Navigating;
 
-		/// <summary>
-		/// Fires when the open URL request is done.
-		/// </summary>
-		public event EventHandler<WebNavigatingEventArgs> Navigated;
+        /// <summary>
+        /// Fires when the open URL request is done.
+        /// </summary>
+        public event EventHandler<WebNavigatingEventArgs> Navigated;
 
-		/// <summary>
-		/// Send the Navigating event
-		/// </summary>
-		/// <param name="args"></param>
-		internal void SendNavigating(WebNavigatingEventArgs args)
-		{
-			Navigating?.Invoke(this, args);
-		}
+        /// <summary>
+        /// Send the Navigating event
+        /// </summary>
+        /// <param name="args"></param>
+        internal void SendNavigating(WebNavigatingEventArgs args)
+        {
+            Navigating?.Invoke(this, args);
+        }
 
-		/// <summary>
-		/// Send the Navigated event
-		/// </summary>
-		/// <param name="args"></param>
-		internal void SendNavigated(WebNavigatingEventArgs args)
-	    {
-		    Navigated?.Invoke(this, args);
-	    }		
-	}
+        /// <summary>
+        /// Send the Navigated event
+        /// </summary>
+        /// <param name="args"></param>
+        internal void SendNavigated(WebNavigatingEventArgs args)
+        {
+            Navigated?.Invoke(this, args);
+        }
+
+        public bool HtmlLegacyModeEnabled { get; set; } = false;
+    }
 }

--- a/src/HtmlLabel/Shared/PlatformSpecifics/Android/HtmlLabel.cs
+++ b/src/HtmlLabel/Shared/PlatformSpecifics/Android/HtmlLabel.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms;
+
+using SharedHtmlLabel = LabelHtml.Forms.Plugin.Abstractions.HtmlLabel;
+
+namespace LabelHtml.Forms.Plugin.PlatformSpecifics.Android
+{
+    public static class HtmlLabel
+    {
+        public static readonly BindableProperty HtmlLegacyModeEnabledProperty = BindableProperty.Create("HtmlLegacyModeEnabled", typeof(bool), typeof(SharedHtmlLabel), false, propertyChanged: OnHtmlLegacyModeEnabledPropertyChanged);
+
+        private static void OnHtmlLegacyModeEnabledPropertyChanged(BindableObject element, object oldValue, object newValue)
+        {
+            var label = element as SharedHtmlLabel;
+            label.HtmlLegacyModeEnabled = (bool)newValue;
+        }
+
+        public static bool GetHtmlLegacyModeEnabled(BindableObject element)
+        {
+            return (bool)element.GetValue(HtmlLegacyModeEnabledProperty);
+        }
+
+        public static void SetHtmlLegacyModeEnabled(BindableObject element, bool value)
+        {
+            element.SetValue(HtmlLegacyModeEnabledProperty, value);
+        }
+
+        public static bool GetHtmlLegacyModeEnabled(this IPlatformElementConfiguration<Xamarin.Forms.PlatformConfiguration.Android, Label> config)
+        {
+            return GetHtmlLegacyModeEnabled(config.Element);
+        }
+
+        public static IPlatformElementConfiguration<Xamarin.Forms.PlatformConfiguration.Android, Label> SetHtmlLegacyModeEnabled(this IPlatformElementConfiguration<Xamarin.Forms.PlatformConfiguration.Android, Label> config, bool value)
+        {
+            SetHtmlLegacyModeEnabled(config.Element, value);
+            return config;
+        }
+    }
+}

--- a/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App.Android/Resources/Resource.designer.cs
+++ b/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App.Android/Resources/Resource.designer.cs
@@ -15,7 +15,7 @@ namespace HtmlLabel.Forms.Plugin.Tests.App.Droid
 {
 	
 	
-	[System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App/HtmlSources.Designer.cs
+++ b/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App/HtmlSources.Designer.cs
@@ -106,6 +106,15 @@ namespace HtmlLabel.Forms.Plugin.Tests.App {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut tortor massa, fringilla ornare congue id, maximus eleifend justo. Donec ipsum nulla, hendrerit ut scelerisque nec, pellentesque in lorem.&lt;/p&gt;&lt;ol&gt;&lt;li&gt;test 1&lt;/li&gt;&lt;li&gt;Test 2&lt;ol&gt;&lt;li&gt;Test 2.1&lt;/li&gt;&lt;li&gt;test 2.2&lt;/li&gt;&lt;/ol&gt;&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Donec pharetra quam mi, ac mollis lacus ultrices vitae. Aenean vitae suscipit felis. Donec convallis orci vitae magna consectetur, lobortis vulputate lectus ultrices.&lt;/p&gt;&lt;p&gt;Maecenas fermentum leo non augue sagittis consecte [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string Demo {
+            get {
+                return ResourceManager.GetString("Demo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An &lt;em&gt;italic&lt;/em&gt; string..
         /// </summary>
         public static string Italic {
@@ -183,6 +192,24 @@ namespace HtmlLabel.Forms.Plugin.Tests.App {
         public static string LinkWithoutUnderline {
             get {
                 return ResourceManager.GetString("LinkWithoutUnderline", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;ol&gt;&lt;li&gt;Test&lt;/li&gt;&lt;li&gt;Test 2&lt;/li&gt;&lt;/ol&gt;&lt;ul&gt;&lt;li&gt;Test 1&lt;/li&gt;&lt;li&gt;Test 2&lt;/li&gt;&lt;/ul&gt;.
+        /// </summary>
+        public static string Lists {
+            get {
+                return ResourceManager.GetString("Lists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut tortor massa, fringilla ornare congue id, maximus eleifend justo. Donec ipsum nulla, hendrerit ut scelerisque nec, pellentesque in lorem.&lt;/p&gt;&lt;p&gt;Donec pharetra quam mi, ac mollis lacus ultrices vitae. Aenean vitae suscipit felis. Donec convallis orci vitae magna consectetur, lobortis vulputate lectus ultrices.&lt;/p&gt;&lt;p&gt;Maecenas fermentum leo non augue sagittis consectetur. Quisque feugiat a magna sit amet tempus. Morbi ac ornare nibh, in viverra dui [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string Paragraphs {
+            get {
+                return ResourceManager.GetString("Paragraphs", resourceCulture);
             }
         }
     }

--- a/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App/HtmlSources.resx
+++ b/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App/HtmlSources.resx
@@ -132,6 +132,9 @@
   <data name="Color" xml:space="preserve">
     <value>Red color string</value>
   </data>
+  <data name="Demo" xml:space="preserve">
+    <value>&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut tortor massa, fringilla ornare congue id, maximus eleifend justo. Donec ipsum nulla, hendrerit ut scelerisque nec, pellentesque in lorem.&lt;/p&gt;&lt;ol&gt;&lt;li&gt;test 1&lt;/li&gt;&lt;li&gt;Test 2&lt;ol&gt;&lt;li&gt;Test 2.1&lt;/li&gt;&lt;li&gt;test 2.2&lt;/li&gt;&lt;/ol&gt;&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Donec pharetra quam mi, ac mollis lacus ultrices vitae. Aenean vitae suscipit felis. Donec convallis orci vitae magna consectetur, lobortis vulputate lectus ultrices.&lt;/p&gt;&lt;p&gt;Maecenas fermentum leo non augue sagittis consectetur. Quisque feugiat a magna sit amet tempus. Morbi ac ornare nibh, in viverra dui. Quisque iaculis ipsum sapien, vel lobortis velit blandit sed. Vivamus ac congue nunc.&lt;/p&gt;&lt;ul&gt;&lt;li&gt;test 1&lt;/li&gt;&lt;li&gt;Test 2&lt;ul&gt;&lt;li&gt;Test 2.1&lt;/li&gt;&lt;li&gt;test 2.2&lt;/li&gt;&lt;/ul&gt;&lt;/li&gt;&lt;/ul&gt;</value>
+  </data>
   <data name="Italic" xml:space="preserve">
     <value>An &lt;em&gt;italic&lt;/em&gt; string.</value>
   </data>
@@ -158,5 +161,11 @@
   </data>
   <data name="LinkWithoutUnderline" xml:space="preserve">
     <value>This is a &lt;a href="https://github.com/matteobortolazzo/HtmlLabelPlugin"&gt;Link&lt;/a&gt; with no underline.</value>
+  </data>
+  <data name="Lists" xml:space="preserve">
+    <value>&lt;ol&gt;&lt;li&gt;Test&lt;/li&gt;&lt;li&gt;Test 2&lt;/li&gt;&lt;/ol&gt;&lt;ul&gt;&lt;li&gt;Test 1&lt;/li&gt;&lt;li&gt;Test 2&lt;/li&gt;&lt;/ul&gt;</value>
+  </data>
+  <data name="Paragraphs" xml:space="preserve">
+    <value>&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut tortor massa, fringilla ornare congue id, maximus eleifend justo. Donec ipsum nulla, hendrerit ut scelerisque nec, pellentesque in lorem.&lt;/p&gt;&lt;p&gt;Donec pharetra quam mi, ac mollis lacus ultrices vitae. Aenean vitae suscipit felis. Donec convallis orci vitae magna consectetur, lobortis vulputate lectus ultrices.&lt;/p&gt;&lt;p&gt;Maecenas fermentum leo non augue sagittis consectetur. Quisque feugiat a magna sit amet tempus. Morbi ac ornare nibh, in viverra dui. Quisque iaculis ipsum sapien, vel lobortis velit blandit sed. Vivamus ac congue nunc.&lt;/p&gt;</value>
   </data>
 </root>

--- a/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App/MainPage.xaml
+++ b/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App/MainPage.xaml
@@ -1,76 +1,93 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentPage x:Class="HtmlLabel.Forms.Plugin.Tests.App.MainPage"
+             xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:htmlLabel="clr-namespace:LabelHtml.Forms.Plugin.Abstractions;assembly=HtmlLabel.Forms.Plugin"
+             xmlns:htmlLabelAndroid="clr-namespace:LabelHtml.Forms.Plugin.PlatformSpecifics.Android;assembly=HtmlLabel.Forms.Plugin"
              xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
-             mc:Ignorable="d"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              ios:Page.UseSafeArea="true"
              FlowDirection="{x:Static Device.FlowDirection}"
-             x:Class="HtmlLabel.Forms.Plugin.Tests.App.MainPage">
-    <ScrollView>
-        <StackLayout Padding="10">            
-            <StackLayout>  
-                <Label Text="Bold" />
-                <htmlLabel:HtmlLabel Text="{Binding Bold}" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Italic" />
-                <htmlLabel:HtmlLabel Text="{Binding Italic}" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Red color" />
-                <htmlLabel:HtmlLabel Text="{Binding Color}" TextColor="Red" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Align center" />
-                <htmlLabel:HtmlLabel Text="{Binding AlignCenter}" HorizontalTextAlignment="Center" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Align end" />
-                <htmlLabel:HtmlLabel Text="{Binding AlignEnd}" HorizontalTextAlignment="End" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Links" />
-                <htmlLabel:HtmlLabel Text="{Binding Links}" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Links with options" />
-                <htmlLabel:HtmlLabel Text="{Binding LinksWithOptions}" BrowserLaunchOptions="{Binding BrowserLaunchOptions}" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Links to email" />
-                <htmlLabel:HtmlLabel Text="{Binding LinkToEmail}" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Links to phone dial" />
-                <htmlLabel:HtmlLabel Text="{Binding LinkToTel}" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Links to SMS" />
-                <htmlLabel:HtmlLabel Text="{Binding LinkToSms}" />
-            </StackLayout>            
-            <StackLayout>
-                <Label Text="Links with different color" />
-                <htmlLabel:HtmlLabel Text="{Binding LinkWithColor}" LinkColor="Green" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Links with no underline" />
-                <htmlLabel:HtmlLabel Text="{Binding LinkWithoutUnderline}" UnderlineText="False" />
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Links with gestures" />
-                <htmlLabel:HtmlLabel Text="{Binding LinkWithGestures}">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding Clicked}" />
-                    </Label.GestureRecognizers>
-                </htmlLabel:HtmlLabel>
-            </StackLayout>
-            <StackLayout>
-                <Label Text="Arab" />
-                <htmlLabel:HtmlLabel Text="{Binding Arab}" />
-            </StackLayout>
-        </StackLayout>
-    </ScrollView>
+             mc:Ignorable="d">
+  <ScrollView>
+    <StackLayout Padding="10">
+      <StackLayout>
+        <Label Text="Bold" />
+        <htmlLabel:HtmlLabel Text="{Binding Bold}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Italic" />
+        <htmlLabel:HtmlLabel Text="{Binding Italic}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Red color" />
+        <htmlLabel:HtmlLabel Text="{Binding Color}" TextColor="Red" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Align center" />
+        <htmlLabel:HtmlLabel HorizontalTextAlignment="Center" Text="{Binding AlignCenter}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Align end" />
+        <htmlLabel:HtmlLabel HorizontalTextAlignment="End" Text="{Binding AlignEnd}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Links" />
+        <htmlLabel:HtmlLabel Text="{Binding Links}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Links with options" />
+        <htmlLabel:HtmlLabel BrowserLaunchOptions="{Binding BrowserLaunchOptions}" Text="{Binding LinksWithOptions}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Links to email" />
+        <htmlLabel:HtmlLabel Text="{Binding LinkToEmail}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Links to phone dial" />
+        <htmlLabel:HtmlLabel Text="{Binding LinkToTel}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Links to SMS" />
+        <htmlLabel:HtmlLabel Text="{Binding LinkToSms}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Links with different color" />
+        <htmlLabel:HtmlLabel LinkColor="Green" Text="{Binding LinkWithColor}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Links with no underline" />
+        <htmlLabel:HtmlLabel Text="{Binding LinkWithoutUnderline}" UnderlineText="False" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Links with gestures" />
+        <htmlLabel:HtmlLabel Text="{Binding LinkWithGestures}">
+          <Label.GestureRecognizers>
+            <TapGestureRecognizer Command="{Binding Clicked}" />
+          </Label.GestureRecognizers>
+        </htmlLabel:HtmlLabel>
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Lists" />
+        <htmlLabel:HtmlLabel Text="{Binding Lists}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Paragraphs default (CompactMode)" />
+        <htmlLabel:HtmlLabel Text="{Binding Paragraphs}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Paragraphs (LegacyMode)" />
+        <htmlLabel:HtmlLabel htmlLabelAndroid:HtmlLabel.HtmlLegacyModeEnabled="True" Text="{Binding Paragraphs}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Demo text" />
+        <htmlLabel:HtmlLabel htmlLabelAndroid:HtmlLabel.HtmlLegacyModeEnabled="True" Text="{Binding Demo}" />
+      </StackLayout>
+      <StackLayout>
+        <Label Text="Arab" />
+        <htmlLabel:HtmlLabel Text="{Binding Arab}" />
+      </StackLayout>
+    </StackLayout>
+  </ScrollView>
 </ContentPage>

--- a/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App/MainPage.xaml.cs
+++ b/tests/HtmlLabel.Forms.Plugin.Tests.App/HtmlLabel.Forms.Plugin.Tests.App/MainPage.xaml.cs
@@ -5,41 +5,44 @@ using Colors = System.Drawing.Color;
 
 namespace HtmlLabel.Forms.Plugin.Tests.App
 {
-    // Learn more about making custom code visible in the Xamarin.Forms previewer
-    // by visiting https://aka.ms/xamarinforms-previewer
-    [DesignTimeVisible(false)]
-    public partial class MainPage : ContentPage
+  // Learn more about making custom code visible in the Xamarin.Forms previewer
+  // by visiting https://aka.ms/xamarinforms-previewer
+  [DesignTimeVisible(false)]
+  public partial class MainPage : ContentPage
+  {
+    public MainPage()
     {
-        public MainPage()
-        {
-            InitializeComponent();
-            BindingContext = new Sources();
-        }
+      InitializeComponent();
+      this.BindingContext = new Sources();
     }
+  }
 
-    public class Sources
+  public class Sources
+  {
+    public string Bold => HtmlSources.Bold;
+    public string Italic => HtmlSources.Italic;
+    public string Color => HtmlSources.Color;
+    public string AlignCenter => HtmlSources.AlignCenter;
+    public string AlignEnd => HtmlSources.AlignEnd;
+    public string Links => HtmlSources.Links;
+    public string LinksWithOptions => HtmlSources.LinksWithOptions;
+    public string LinkToEmail => HtmlSources.LinkToEmail;
+    public string LinkToTel => HtmlSources.LinkToTel;
+    public string LinkToSms => HtmlSources.LinkToSms;
+    public string LinkWithColor => HtmlSources.LinkWithColor;
+    public string LinkWithoutUnderline => HtmlSources.LinkWithoutUnderline;
+    public string LinkWithGestures => HtmlSources.LinkWithGestures;
+    public string Lists => HtmlSources.Lists;
+    public string Paragraphs => HtmlSources.Paragraphs;
+    public string Demo => HtmlSources.Demo;
+    public string Arab => HtmlSources.Arab;
+    public Command Clicked => new Command(() => Browser.OpenAsync("https://github.com/matteobortolazzo/HtmlLabelPlugin"));
+    public BrowserLaunchOptions BrowserLaunchOptions => new BrowserLaunchOptions
     {
-        public string Bold => HtmlSources.Bold;
-        public string Italic => HtmlSources.Italic;
-        public string Color => HtmlSources.Color;
-        public string AlignCenter => HtmlSources.AlignCenter;
-        public string AlignEnd => HtmlSources.AlignEnd;
-        public string Links => HtmlSources.Links;
-        public string LinksWithOptions => HtmlSources.LinksWithOptions;
-        public string LinkToEmail => HtmlSources.LinkToEmail;
-        public string LinkToTel => HtmlSources.LinkToTel;
-        public string LinkToSms => HtmlSources.LinkToSms;
-        public string LinkWithColor => HtmlSources.LinkWithColor;
-        public string LinkWithoutUnderline => HtmlSources.LinkWithoutUnderline;
-        public string LinkWithGestures => HtmlSources.LinkWithGestures;
-        public string Arab => HtmlSources.Arab;
-        public Command Clicked => new Command(() => Browser.OpenAsync("https://github.com/matteobortolazzo/HtmlLabelPlugin"));
-        public BrowserLaunchOptions BrowserLaunchOptions => new BrowserLaunchOptions
-        {
-            LaunchMode = BrowserLaunchMode.SystemPreferred,
-            TitleMode = BrowserTitleMode.Show,
-            PreferredToolbarColor = Colors.AliceBlue,
-            PreferredControlColor = Colors.Violet
-        };
-    }
+      LaunchMode = BrowserLaunchMode.SystemPreferred,
+      TitleMode = BrowserTitleMode.Show,
+      PreferredToolbarColor = Colors.AliceBlue,
+      PreferredControlColor = Colors.Violet
+    };
+  }
 }


### PR DESCRIPTION
Hi Matteo,

Really like your plugin but it didn't fully fit my needs since the rendered output in Android is different from the output in iOS. Turns out the CompactMode in FromHtml (used in the Android renderer) is removing white spacing from paragraphs, this is not the case on iOS. Since we use the P-tag a lot I decided to add an Android specific so it would be possible to switch between CompactMode (default) and LegacyMode. Would you be willing to include this in your project?

```xaml
xmlns:htmlLabel="clr-namespace:LabelHtml.Forms.Plugin.Abstractions;assembly=HtmlLabel.Forms.Plugin"
xmlns:htmlLabelAndroid="clr-namespace:LabelHtml.Forms.Plugin.PlatformSpecifics.Android;assembly=HtmlLabel.Forms.Plugin"
...
<StackLayout>
    <Label Text="Paragraphs (LegacyMode)" />
    <htmlLabel:HtmlLabel htmlLabelAndroid:HtmlLabel.HtmlLegacyModeEnabled="True" Text="{Binding Paragraphs}" />
</StackLayout>
```