### PR TITLE
Replace line and character counting with a range check

### DIFF
--- a/src/HtmlLabel/iOS/LinkTapHelper.cs
+++ b/src/HtmlLabel/iOS/LinkTapHelper.cs
@@ -61,13 +61,10 @@ namespace LabelHtml.Forms.Plugin.iOS
 
 			// Find tapped character
 			CGPoint locationOfTouchInLabel = tap.LocationInView(control);
-			var locationOfTouchInTextContainer = new CGPoint(locationOfTouchInLabel .X - xOffset, locationOfTouchInLabel .Y - yOffset);
+			var locationOfTouchInTextContainer = new CGPoint(locationOfTouchInLabel.X - xOffset, locationOfTouchInLabel.Y - yOffset);
 			var characterIndex = (nint)layoutManager.GetCharacterIndex(locationOfTouchInTextContainer, textContainer);
-			var lineTapped = ((int)Math.Ceiling(locationOfTouchInLabel.Y / control.Font.LineHeight)) - 1;
-			var rightMostPointInLineTapped = new CGPoint(bounds.Size.Width, control.Font.LineHeight * lineTapped);
-			var charsInLineTapped = (nint)layoutManager.GetCharacterIndex(rightMostPointInLineTapped, textContainer);
 
-			if (characterIndex > charsInLineTapped)
+			if (characterIndex >= attributedText.Length)
 			{
 				return null;
 			}


### PR DESCRIPTION
On multiple line labels, iOS 12 <code>charsInLineTapped</code> returns too short a value if the link tapped is after the first line in the label.  The result is the comparison to <code>characterIndex</code> is a null return (so nothing happens), yet the user tapped a valid url string to return.  Comparing iOS 12 to iOS 13, I <I>suspect</I> this is due to a different value being returned for <code>control.Font.LineHeight</code> between those versions of iOS and ultimately impacting the value of <code>charsInLineTapped</code>.

However, it appears as though the math performed here isn't necessary to determine if <code>characterIndex</code> is within acceptable bounds.  It can be compared to the total number of characters in the label, represented by the <code>Length</code> property on <code>attributedText</code>.

This change has been successfully tested on both an iOS 12 and 13 device.