### PR TITLE
Fixed html in ListView and removed all trailing newlines

### DIFF
--- a/src/HtmlLabel/Android/Renderer.cs
+++ b/src/HtmlLabel/Android/Renderer.cs
@@ -41,7 +41,7 @@ namespace LabelHtml.Forms.Plugin.Droid
 		{
 			base.OnElementChanged(e);
 
-			if (e == null || e.OldElement != null || Element == null)
+			if (e == null || Element == null)
 			{
 				return;
 			}
@@ -134,19 +134,27 @@ namespace LabelHtml.Forms.Plugin.Droid
 			}
 
 			// Android adds an unnecessary "\n" that must be removed
-			using ISpanned value = RemoveLastChar(strBuilder);
+			using ISpanned value = RemoveTrailingNewLines(strBuilder);
 
 			// Finally sets the value of the TextView 
 			control.SetText(value, TextView.BufferType.Spannable);
 		}
 
-		private static ISpanned RemoveLastChar(ICharSequence text)
+		private static ISpanned RemoveTrailingNewLines(ICharSequence text)
 		{
 			var builder = new SpannableStringBuilder(text);
-			if (text.Length() != 0)
+
+			var count = 0;
+			for (int i = 1; i <= text.Length(); i++)
 			{
-				_ = builder.Delete(text.Length() - 2, text.Length());
+				if (!'\n'.Equals(text.CharAt(text.Length() - i)))
+					break;
+				
+				count++;
 			}
+
+			if (count > 0)
+				_ = builder.Delete(text.Length() - count, text.Length());
 
 			return builder;
 		}

--- a/src/HtmlLabel/iOS/Renderer.cs
+++ b/src/HtmlLabel/iOS/Renderer.cs
@@ -27,7 +27,7 @@ namespace LabelHtml.Forms.Plugin.iOS
 		{
 			base.OnElementChanged(e);
 
-			if (e == null || e.OldElement != null || Element == null)
+			if (e == null || Element == null)
 			{
 				return;
 			}

--- a/src/HtmlLabel/iOS/Renderer.cs
+++ b/src/HtmlLabel/iOS/Renderer.cs
@@ -93,7 +93,7 @@ namespace LabelHtml.Forms.Plugin.iOS
 			var nsError = new NSError();
 			var htmlData = NSData.FromString(html, NSStringEncoding.Unicode);
 			using var htmlString = new NSAttributedString(htmlData, stringType, ref nsError);
-			NSMutableAttributedString mutableHtmlString = RemoveTrailingNewLine(htmlString);
+			NSMutableAttributedString mutableHtmlString = RemoveTrailingNewLines(htmlString);
 
 			SetLineHeight(element, mutableHtmlString);
 			SetLinksStyles(element, mutableHtmlString);
@@ -105,13 +105,19 @@ namespace LabelHtml.Forms.Plugin.iOS
 			}
 		}
 
-		private static NSMutableAttributedString RemoveTrailingNewLine(NSAttributedString htmlString)
+		private static NSMutableAttributedString RemoveTrailingNewLines(NSAttributedString htmlString)
 		{
-			NSAttributedString lastCharRange = htmlString.Substring(htmlString.Length - 1, 1);
-			if (lastCharRange.Value == "\n")
+			var count = 0;
+			for (int i = 1; i <= htmlString.Length; i++)
 			{
-				htmlString = htmlString.Substring(0, htmlString.Length - 1);
+				if (!"\n".Equals(htmlString.Substring(htmlString.Length - i, 1)))
+					break;
+
+				count++;
 			}
+
+			if (count > 0)
+				htmlString = htmlString.Substring(0, htmlString.Length - count);
 
 			return new NSMutableAttributedString(htmlString);
 		}

--- a/src/HtmlLabel/iOS/Renderer.cs
+++ b/src/HtmlLabel/iOS/Renderer.cs
@@ -110,7 +110,7 @@ namespace LabelHtml.Forms.Plugin.iOS
 			var count = 0;
 			for (int i = 1; i <= htmlString.Length; i++)
 			{
-				if (!"\n".Equals(htmlString.Substring(htmlString.Length - i, 1)))
+				if ("\n" != htmlString.Substring(htmlString.Length - i, 1).Value)
 					break;
 
 				count++;


### PR DESCRIPTION
I had two problems when using this library:

**1)** When I have the html label in a ListView while some of the rows have plain text, some html and some none, after pull-refreshing the ListView, all the rows are displayed as plain text with html tags.

This is fixed when I remove `e.OldElement != null` condition from `OnElementChanged` method. This seems to me as a bug, why would we abort the `ProcessText()` when the renderer has an OldElement? I don't think there is any reason for that and it prevents the text processing when the renderer is somehow reused.

**2)** I still have trailing new lines on every html label - so I added a for loop, removing **all** trailing new lines, not just the last one. On Android for example, I got `\n\n\n` on every html label.

--
I had both issues on both iOS and Android, tested on iPhone XS iOS 13 and Honor 5X Android 6.
Both issues resolved and tested.