### PR TITLE
Fixes for issues 111, 112

### DIFF
--- a/src/HtmlLabel/Android/Renderer.cs
+++ b/src/HtmlLabel/Android/Renderer.cs
@@ -88,7 +88,7 @@ namespace LabelHtml.Forms.Plugin.Droid
 
 			Control.SetIncludeFontPadding(false);
 			var isRtl = Device.FlowDirection == FlowDirection.RightToLeft;
-			var styledHtml = new RendererHelper(Element, Control.Text, Device.RuntimePlatform, isRtl).ToString();
+			var styledHtml = new RendererHelper(Element, Element.Text, Device.RuntimePlatform, isRtl).ToString();
 			/* 
 			 * Android's TextView doesn't support lists.
 			 * List tags must be replaces with custom tags,

--- a/src/HtmlLabel/UWP/Renderer.cs
+++ b/src/HtmlLabel/UWP/Renderer.cs
@@ -65,7 +65,7 @@ namespace LabelHtml.Forms.Plugin.UWP
 
 			// Gets the complete HTML string
 			var isRtl = Device.FlowDirection == Xamarin.Forms.FlowDirection.RightToLeft;
-			var styledHtml = new RendererHelper(Element, Control.Text, Device.RuntimePlatform, isRtl).ToString();
+			var styledHtml = new RendererHelper(Element, Element.Text, Device.RuntimePlatform, isRtl).ToString();
 			if (styledHtml == null)
 			{
 				return;

--- a/src/HtmlLabel/iOS/Renderer.cs
+++ b/src/HtmlLabel/iOS/Renderer.cs
@@ -61,7 +61,7 @@ namespace LabelHtml.Forms.Plugin.iOS
 
 		private void ProcessText()
 		{
-			if (Control == null || Element == null)
+			if (Control == null || Element == null || UIApplication.SharedApplication.ApplicationState == UIApplicationState.Background)
             {
                 return;
             }

--- a/src/HtmlLabel/iOS/Renderer.cs
+++ b/src/HtmlLabel/iOS/Renderer.cs
@@ -73,7 +73,7 @@ namespace LabelHtml.Forms.Plugin.iOS
 			}
 
 			var isRtl = Device.FlowDirection == FlowDirection.RightToLeft;
-			var styledHtml = new RendererHelper(Element, Control.Text, Device.RuntimePlatform, isRtl).ToString();
+			var styledHtml = new RendererHelper(Element, Element.Text, Device.RuntimePlatform, isRtl).ToString();
 			if (styledHtml != null)
 			{
 				SetText(Control, styledHtml);


### PR DESCRIPTION
[iOS] Does not attempt to re-render HTML if the application is in the background. (#111)
[iOS] Always re-render HTML when the application enters the foreground.
[All Platforms] Uses correct source for HTML content. (#112)

The iOS changes are required to support theming (e.g dark mode).